### PR TITLE
minor change to get it working on my precise32 vagrant virtualbox

### DIFF
--- a/gitlab.yml
+++ b/gitlab.yml
@@ -169,6 +169,7 @@
     # way to go for reliably restarting gitlab.
     - name: kill erroneous puma socket file
       command: rm /home/git/gitlab/tmp/sockets/gitlab.socket
+      ignore_errors: yes
     - name: stop GitLab
       command: /etc/init.d/gitlab stop
       ignore_errors: yes


### PR DESCRIPTION
This ansible-playbook almost ran straight through, but it kicked out when trying to rm a stale gitlab.socket that didn't yet exist.  I just copied the "ignore_errors: yes" line used in the tasks right below that line and it worked fine.  Nice playbook!
