### PR TITLE
Added Vagrantfile that provisions this play book;

### DIFF
--- a/HostFile.example
+++ b/HostFile.example
@@ -1,0 +1,2 @@
+[gitlab]
+192.168.33.10 ansible_connection=ssh ansible_ssh_user=vagrant ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key

--- a/gitlab.yml
+++ b/gitlab.yml
@@ -84,7 +84,7 @@
     - vars.yml
   tasks:
     - name: ensure Gitlab-Shell git repository is cloned
-      git: repo=https://github.com/gitlabhq/gitlab-shell.git dest=/home/git/gitlab-shell version=v1.5.0
+      git: repo=https://github.com/gitlabhq/gitlab-shell.git dest=/home/git/gitlab-shell version=v1.7.0
     - name: ensure config is copied from example
       command: cp /home/git/gitlab-shell/config.yml.example /home/git/gitlab-shell/config.yml creates=/home/git/gitlab-shell/config.yml
     - name: ensure gitlab-shell config is written

--- a/templates/Vagrantfile
+++ b/templates/Vagrantfile
@@ -1,0 +1,38 @@
+#Instructions:
+# 1) Install Vagrant (vagrantup.com), VirtualBox (virtualbox.org), and Git (git-scm.com)
+# 2) Make a folder where you wish to run this VM ("Working Directory")
+# 3) run: vagrant init
+# 4) Clone the repo (see GitHub link) into the Working Directory 
+# 5) Move the Vagrant file to the top most Working Directory
+# 6) Change the permissions of the Vagrant ssh key (chmod +r ~/.vagrant.d/insecure_private_key)
+# 7) Run Vagrant up and see automation FTW
+Vagrant::Config.run do |config|
+  config.vm.box = "precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  
+  # OPTIONAL System Settings:
+  # I used this to put some more "muscle" behind my VM's
+  #config.vm.customize ["modifyvm", :id, "--memory", 2048]
+  #config.vm.customize ["modifyvm", :id, "--cpus", "2"]  
+  #config.vm.customize ["modifyvm", :id, "--ioapic", "on"]
+
+  # Netorking Static
+  #config.vm.network :hostonly, "192.168.33.10"
+  
+  # Networking "Dynamic" (NOTE: this bit is for non-Vagrant provisioning)
+  # If you want the vm to have be in bridged mode during setup add the following
+  # mac to be DHCP reserved BEFORE running vagrant up! Also, change HostFile's
+  # IP to match the reserved IP entry. ALSO, comment the host only line above.
+  config.vm.network :bridged, :bridge  => "wlan0", :mac => "080808080808"
+
+  config.vm.provision :ansible do |ansible|
+     ansible.playbook = "./ansible-playbook-gitlab/gitlab.yml"
+     ansible.inventory_file = "./ansible-playbook-gitlab/HostFile"
+  end
+
+  # !HOTFIX! For some reason on Ubuntu 13.04 x86_64 the gitlab service DOES NOT
+  # start! You have to remove the socket and restart the service. I have made
+  # a quick hotfix bash script to automate this process.
+  config.vm.provision :shell, :path => "./ansible-playbook-gitlab/templates/precise64_hotfix.sh"
+
+end

--- a/templates/precise64_hotfix.sh
+++ b/templates/precise64_hotfix.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sudo rm /home/git/gitlab/tmp/sockets/gitlab.socket
+sudo /etc/init.d/gitlab start


### PR DESCRIPTION
 There's a 'hotfix' due to an issue I have on ubuntu 12.04. The tmp socket errors out for the "erroneous"/"extraneous"  clean up, so I have to manually remove the socket. Then I simply restart gitlab, and presto GitLab boots! 
